### PR TITLE
Add stubs for ZendHQ monitoring functions

### DIFF
--- a/src/include.php
+++ b/src/include.php
@@ -5,3 +5,5 @@ declare(strict_types=1);
 if (! class_exists(ZendHQ\JobQueue\Queue::class, false)) {
     require_once __DIR__ . '/stubs.php';
 }
+
+require_once __DIR__ . '/monitoring_stubs.php';

--- a/src/monitoring_stubs.php
+++ b/src/monitoring_stubs.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+if (! function_exists('monitor_custom_event')) {
+    function monitor_custom_event(
+        string $type,
+        string $text,
+        mixed $userData = null,
+        int $userSeverity = -2
+    ) : ?bool {}
+}
+
+if (! function_exists('monitor_custom_event_ex')) {
+    function monitor_custom_event_ex(
+        string $type,
+        string $text,
+        string $ruleName,
+        mixed $userData = null
+    ) : ?bool {}
+}
+
+if (! function_exists('zend_monitor_custom_event')) {
+    /**
+     * @deprecated Use monitor_custom_event() instead
+     */
+    function zend_monitor_custom_event(
+        string $type,
+        string $text,
+        mixed $userData = null,
+        int $userSeverity = -2
+    ) : ?bool {}
+}
+
+if (! function_exists('zend_monitor_custom_event_ex')) {
+    /**
+     * @deprecated Use monitor_custom_event_ex() instead
+     */
+    function zend_monitor_custom_event_ex(
+        string $type,
+        string $text,
+        string $ruleName,
+        mixed $userData = null
+    ) : ?bool {}
+}


### PR DESCRIPTION
This patch adds stubs for each of:

- monitor_custom_event
- monitor_custom_event_ex
- zend_monitor_custom_event
- zend_monitor_custom_event_ex
